### PR TITLE
Fix cramped high page numbers on blockchain page

### DIFF
--- a/css/ngtable.less
+++ b/css/ngtable.less
@@ -30,8 +30,8 @@
     float: left;
     text-align: center;
     height: 32px;
-    width: 32px;
-    padding: 5px 0;
+    min-width: 22px;
+    padding: 5px;
     line-height: 32px;
     margin-right: 12px;
     border-radius: 4px;


### PR DESCRIPTION
See the screenshot of what the problem was:
![](https://cloud.githubusercontent.com/assets/1254342/19839189/b46be98c-9edd-11e6-94bd-e58c3cb4b1c7.png)
