### PR TITLE
Use jit-grunt to slightly speed up grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,9 @@
 module.exports = function (grunt) {
+    require('jit-grunt')(grunt, {
+      'nggettext_extract': 'grunt-angular-gettext',
+      'nggettext_compile': 'grunt-angular-gettext',
+    }); 
+
     var files = [
         "js/main.js",
         "js/modal.js",
@@ -117,14 +122,6 @@ module.exports = function (grunt) {
           }
         }
     });
-
-    grunt.loadNpmTasks("grunt-angular-gettext");
-    grunt.loadNpmTasks("grunt-contrib-concat");
-    grunt.loadNpmTasks("grunt-contrib-cssmin");
-    grunt.loadNpmTasks("grunt-contrib-less");
-    grunt.loadNpmTasks("grunt-contrib-uglify");
-    grunt.loadNpmTasks("grunt-browserify");
-    grunt.loadNpmTasks("grunt-contrib-watch");
 
     grunt.registerTask("default", ["watch"]);
     grunt.registerTask("release", ["nggettext_extract", "nggettext_compile", "less", "cssmin", "concat:release", "browserify", "concat:withoutBrowserify", "uglify:release"]);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "grunt-contrib-less": "=1.4.0",
     "grunt-contrib-nodeunit": "=1.0.0",
     "grunt-contrib-uglify": "=2.0.0",
-    "grunt-contrib-watch": "latest"
+    "grunt-contrib-watch": "latest",
+    "jit-grunt": "^0.10.0",
   },
   "dependencies": {
     "angular": "=1.5.8",


### PR DESCRIPTION
and make Gruntfile.js less cluttered with loading tasks.

Though the big slow thing in grunt is browserify. It takes 9 seconds on my machine (Older laptop, no SSD). I tried to use [watchify](https://github.com/substack/watchify) to speed things up and it is really fast, almost immediate. There is even [grunt-watchify](https://www.npmjs.com/package/grunt-watchify) task or a [watch](https://github.com/jmreidy/grunt-browserify#watch) option in grunt-browserify that runs watchify. 
But the downside is that there have to be two watch scripts running and the setup is a bit cumbersome. I'll try to look more into it.