### PR TITLE
tasks can be executed as npm commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,22 @@ This repository contains the [AngularJS](https://angularjs.org/) based user-inte
 
 ## Installation
 
-Install node modules:
+Install frontend dependencies (will run the `bower install` after the npm instalation):
 
 ```
 npm install
 ```
 
-Install bower components:
+Install bower components (optional and already happening in `npm install`):
 
 ```
-bower install
+npm run bower-install
 ```
 
 Build the user-interface:
 
 ```
-grunt release
+npm run grunt-release
 ```
 
 ## Authors

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   "private": true,
   "author": "Vera Nekrasova <vera.limita@gmail.com>, Boris Povod <boris@crypti.me>",
   "license": "MIT",
+  "scripts": {
+    "postinstall": "bower install",
+    "bower-install": "bower install",
+    "grunt-release": "grunt release"
+  },
   "devDependencies": {
     "browserify": "latest",
     "grunt": "=1.0.1",


### PR DESCRIPTION
Remove the need of having to install `bower` and `grunt` globally in order to run the frontend.

You can install bower components by typing `npm run bower-install {myawesomepackaje}`

Other scripts that were running this commands could as well be changed, in order to keep the dependencies simpler (installing globally npm packages is not something you always like)