### PR TITLE
Allow to set cookies with passphrase and first state

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Build the user-interface:
 npm run grunt-release
 ```
 
+You can set the following cookies (e.g. using [EditThisCookies](http://www.editthiscookie.com/)) for more comfortable local development:
+- `passphrase` - passphrase to sign you in  
+- `goto` - name of state to go to. See [possible state names](https://github.com/LiskHQ/lisk-ui/blob/development/js/app.js#L25-L100).
+
+
 ## Authors
 
 - Vera Nekrasova <vera.limita@gmail.com>

--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,7 @@ require('angular');
 require('angular-ui-router');
 require('angular-resource');
 require('angular-filter');
+require('angular-cookies');
 require('browserify-angular-animate');
 require('../node_modules/angular-animate/angular-animate.js')
 require('../node_modules/angular-gettext/dist/angular-gettext.min.js');
@@ -11,7 +12,7 @@ require('../node_modules/ng-table/dist/ng-table.js');
 
 Mnemonic = require('bitcore-mnemonic');
 
-liskApp = angular.module('liskApp', ['ui.router', 'btford.modal', 'ngTable', 'ngAnimate',  'chart.js', 'btford.socket-io', 'ui.bootstrap', 'angular.filter', 'gettext']);
+liskApp = angular.module('liskApp', ['ui.router', 'btford.modal', 'ngCookies', 'ngTable', 'ngAnimate',  'chart.js', 'btford.socket-io', 'ui.bootstrap', 'angular.filter', 'gettext']);
 
 liskApp.config([
     "$locationProvider",

--- a/js/controllers/passphraseController.js
+++ b/js/controllers/passphraseController.js
@@ -1,6 +1,6 @@
 require('angular');
 
-angular.module('liskApp').controller('passphraseController', ['$scope', '$rootScope', '$http', "$state", "userService", "newUser", 'gettextCatalog', function ($rootScope, $scope, $http, $state, userService, newUser, gettextCatalog) {
+angular.module('liskApp').controller('passphraseController', ['$scope', '$rootScope', '$http', "$state", "userService", "newUser", 'gettextCatalog', '$cookies', function ($rootScope, $scope, $http, $state, userService, newUser, gettextCatalog, $cookies) {
 
     userService.setData();
     userService.rememberPassphrase = false;
@@ -40,11 +40,22 @@ angular.module('liskApp').controller('passphraseController', ['$scope', '$rootSc
                     if (remember) {
                         userService.setSessionPassphrase(pass);
                     }
-                    $state.go('main.dashboard');
+
+                    var goto = $cookies.get('goto');
+                    if (goto) {
+                        $state.go(goto);
+                    } else {
+                        $state.go('main.dashboard');
+                    }
                 } else {
                     $scope.errorMessage = resp.data.error;
                 }
             });
+    }
+    
+    var passphrase = $cookies.get('passphrase');
+    if (passphrase) {
+        $scope.login(passphrase);
     }
 
 }]);

--- a/package.json
+++ b/package.json
@@ -27,12 +27,13 @@
     "grunt-contrib-nodeunit": "=1.0.0",
     "grunt-contrib-uglify": "=2.0.0",
     "grunt-contrib-watch": "latest",
-    "jit-grunt": "^0.10.0",
+    "jit-grunt": "^0.10.0"
   },
   "dependencies": {
     "angular": "=1.5.8",
     "angular-animate": "=1.5.8",
     "angular-chart.js": "=0.10.2",
+    "angular-cookies": "^1.5.8",
     "angular-gettext": "=2.3.7",
     "angular-modal": "=0.5.0",
     "angular-resource": "=1.5.8",

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
     "grunt-contrib-nodeunit": "=1.0.0",
     "grunt-contrib-uglify": "=2.0.0",
     "grunt-contrib-watch": "latest",
-    "jit-grunt": "^0.10.0"
+    "jit-grunt": "=0.10.0"
   },
   "dependencies": {
     "angular": "=1.5.8",
     "angular-animate": "=1.5.8",
     "angular-chart.js": "=0.10.2",
-    "angular-cookies": "^1.5.8",
+    "angular-cookies": "=1.5.8",
     "angular-gettext": "=2.3.7",
     "angular-modal": "=0.5.0",
     "angular-resource": "=1.5.8",


### PR DESCRIPTION
You can set the following cookies (e.g. using [EditThisCookies](http://www.editthiscookie.com/)) for more comfortable local development:
- `passphrase` - passphrase to sign you in  
- `goto` - name of state to go to. See [possible state names](https://github.com/LiskHQ/lisk-ui/blob/development/js/app.js#L25-L100).