### PR TITLE
Limit forged lisk to 2 decimal places

### DIFF
--- a/partials/forging.html
+++ b/partials/forging.html
@@ -22,25 +22,25 @@
     <div class="col-md-3 col-xs-12 col-sm-12">
         <div class="info-panel info-panel-grey">
             <span class="title">{{'Today'|translate}}</span>
-            <span class="plain-text">{{statistics.today  | liskFilter }} LSK</span>
+            <span class="plain-text">{{statistics.today  | liskFilter | number:2 }} LSK</span>
         </div>
     </div>
     <div class="col-md-3 col-xs-12 col-sm-12">
         <div class="info-panel info-panel-grey">
             <span class="title">{{'Last 24 hours'|translate}}</span>
-            <span class="plain-text">{{statistics.last24h  | liskFilter }} LSK</span>
+            <span class="plain-text">{{statistics.last24h  | liskFilter | number:2 }} LSK</span>
         </div>
     </div>
     <div class="col-md-3 col-xs-12 col-sm-12">
         <div class="info-panel info-panel-grey">
             <span class="title">{{'Last 7 days'|translate}}</span>
-            <span class="plain-text">{{statistics.last7d  | liskFilter }} LSK</span>
+            <span class="plain-text">{{statistics.last7d  | liskFilter | number:2 }} LSK</span>
         </div>
     </div>
     <div class="col-md-3 col-xs-12 col-sm-12">
         <div class="info-panel info-panel-grey">
             <span class="title">{{'Last 30 days'|translate}}</span>
-            <span class="plain-text">{{statistics.last30d  | liskFilter }} LSK</span>
+            <span class="plain-text">{{statistics.last30d  | liskFilter | number:2 }} LSK</span>
         </div>
     </div>
 </div>


### PR DESCRIPTION
For the amount of forged lisk during a time period (the ones inside col-md-3), limit to 2 decimal places for better formatting on smaller resolutions

To close #92 