### PR TITLE
Hide forging indicator when access is denied - Fixes #93

### DIFF
--- a/js/controllers/appController.js
+++ b/js/controllers/appController.js
@@ -321,6 +321,7 @@ angular.module('liskApp').controller('appController', ['dappsService', '$scope',
     $scope.getForging = function (cb) {
         $http.get("/api/delegates/forging/status", {params: {publicKey: userService.publicKey}})
             .then(function (resp) {
+                $scope.forgingAllowed = resp.data.success;
                 $scope.forging = resp.data.enabled;
                 $scope.dataToShow.forging = $scope.forging;
                 userService.setForging($scope.forging);

--- a/partials/template.html
+++ b/partials/template.html
@@ -240,7 +240,7 @@
                     <a href="#" class="bold-text" ng-click="registrationDelegate()"><translate>delegate registration</translate></a>
                 </li>
             </ul>
-            <ul class="nav nav-underline pull-right forgin-start" ng-show="delegate.username">
+            <ul class="nav nav-underline pull-right forgin-start" ng-show="delegate.username && forgingAllowed">
                 <li>
                     <span><translate>FORGING</translate>:</span>
                     <div class="switch blue-switch">


### PR DESCRIPTION
Hide forging indicator when access is denied from delegates/forging/status. 