### PR TITLE
Remove account-related information after users logs out - Fixes #87

### DIFF
--- a/js/controllers/accountController.js
+++ b/js/controllers/accountController.js
@@ -39,6 +39,23 @@ angular.module('liskApp').controller('accountController', ['$state','$scope', '$
         $scope.modal = transactionInfo.activate({block: block});
     }
 
+    $scope.resetAppData = function () {
+        $scope.balance = userService.balance = 0;
+        $scope.unconfirmedBalance = userService.unconfirmedBalance = 0;
+
+        $scope.balanceToShow = [0]
+
+        $scope.secondPassphrase = userService.secondPassphrase = 0;
+        $scope.unconfirmedPassphrase = userService.unconfirmedPassphrase = 0;
+
+        userService.multisignatures = userService.u_multisignatures = null;
+        $scope.multisignature = false;
+
+        $scope.delegateInRegistration = userService.delegateInRegistration = null;
+        $scope.delegate = userService.delegate = null;
+        $scope.username = userService.username = null;
+    }
+
     $scope.userInfo = function (userId) {
         $scope.modal = userInfo.activate({userId: userId});
     }
@@ -90,19 +107,21 @@ angular.module('liskApp').controller('accountController', ['$state','$scope', '$
                 }
                 $scope.secondPassphrase = userService.secondPassphrase;
                 $scope.unconfirmedPassphrase = userService.unconfirmedPassphrase;
+            } else {
+                $scope.resetAppData();
             }
         });
     }
 
     $scope.getCandles = function () {
         $http.get("https://explorer.lisk.io/api/candles/getCandles").then(function (response) {
-            $scope.graphs.liskPrice.data = [
+            $scope.graphs.liskPrice.data = (response.data && response.data.candles) ? [
                 response.data.candles.map(
                     function (candle) {
                         return candle.close;
                     }
                 )
-            ];
+            ] : [];
         });
     }
 

--- a/js/controllers/appController.js
+++ b/js/controllers/appController.js
@@ -171,6 +171,7 @@ angular.module('liskApp').controller('appController', ['dappsService', '$scope',
                     userService.u_multisignatures = account.u_multisignatures;
                     userService.secondPassphrase = account.secondSignature || account.unconfirmedSignature;
                     userService.unconfirmedPassphrase = account.unconfirmedSignature;
+                    
                 }
 
                 $scope.balance = userService.balance;

--- a/js/controllers/passphraseController.js
+++ b/js/controllers/passphraseController.js
@@ -8,6 +8,17 @@ angular.module('liskApp').controller('passphraseController', ['$scope', '$rootSc
     $scope.rememberPassphrase = true;
     $scope.errorMessage = "";
 
+    $scope.cleanUpUserData = function () {
+        var userProperties = [ 'address', 'allVotes', 'balance', 'balanceToShow', 'dataToShow', 'unconfirmedBalance',
+            'unconfirmedPassphrase', 'username', 'rememberedPassphrase', 'publicKey', 'delegate'];
+        for (var i = 0; i < userProperties.length; i++) {
+            if ($rootScope[userProperties[i]] != undefined) {
+                $rootScope[userProperties[i]] = null;
+            }
+        }
+    }
+    $scope.cleanUpUserData();
+
     $scope.newUser = function () {
         $scope.newUserModal = newUser.activate({
             destroy: function () {
@@ -52,7 +63,7 @@ angular.module('liskApp').controller('passphraseController', ['$scope', '$rootSc
                 }
             });
     }
-    
+
     var passphrase = $cookies.get('passphrase');
     if (passphrase) {
         $scope.login(passphrase);


### PR DESCRIPTION
I've created a list of properties we're using to maintain account information, after logging out I delete all those properties from $rootScope to ensure next logging will provide fresh data.