### PR TITLE
Fix broken "blockchain loading" page - Fixes #101

### DIFF
--- a/js/controllers/loadingController.js
+++ b/js/controllers/loadingController.js
@@ -12,7 +12,7 @@ angular.module('liskApp').controller("loadingController", ["$scope", "$http", "$
                     if (!resp.data.loaded) {
                         $scope.height = resp.data.now;
                         $scope.blocksCount = resp.data.blocksCount;
-                        $scope.loadingState = Math.floor($scope.height / $scope.blocksCount * 100);
+                        $scope.loadingState = $scope.blocksCount ? Math.floor($scope.height / $scope.blocksCount * 100) : 0;
                     } else {
                         $window.location.href = '/';
                     }

--- a/loading.html
+++ b/loading.html
@@ -39,12 +39,11 @@
             <div class="pass-window">
                 <div class="pass-window-icon"></div>
                 <div class="loading clearfix" class="clearfix" ng-controller="loadingController">
-                    <div class="progress" ng-show="height">
+                    <div class="progress" ng-show="loadingState">
                         <div class="determinate" style="width: {{loadingState}}%"></div>
                     </div>
-                    <h3 class="heading" ng-show="!height || !blocksCount">Blockchain is loading...</h3>
-                    <h3 class="heading" ng-show="height">{{loadingState}}%</h3>
-                    <h3 class="heading" ng-show="height">Blockchain is loading...</h3>
+                    <h3 class="heading" ng-show="loadingState">{{loadingState}}%</h3>
+                    <h3 class="heading">Blockchain is loading...</h3>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This commit makes sure the page won't get into a broken state as reported in the screenshot.

Though I wasn't able to reproduce it. 
Also, the backend API didn't send me data that would allow displaying a progress bar.
