### PR TITLE
Fixing balance updates by limiting the calls the GUI does to 1 - Fixes #53

### DIFF
--- a/js/controllers/accountController.js
+++ b/js/controllers/accountController.js
@@ -136,11 +136,10 @@ angular.module('liskApp').controller('accountController', ['$state','$scope', '$
     }
 
     $scope.$on('updateControllerData', function (event, data) {
-	    $scope.$$listeners.updateControllerData.splice(1);
-        if ((data.indexOf('main.dashboard') != -1 && $state.current.name=="main.dashboard") || data.indexOf('main.transactions') != -1) {
+        $scope.$$listeners.updateControllerData.splice(1);
+        if ((data.indexOf('main.dashboard') != -1 && $state.current.name == 'main.dashboard') || data.indexOf('main.transactions') != -1) {
             $scope.updateAppView();
         }
-
     });
 
     $scope.updateAppView();

--- a/js/controllers/accountController.js
+++ b/js/controllers/accountController.js
@@ -106,12 +106,6 @@ angular.module('liskApp').controller('accountController', ['$state','$scope', '$
         });
     }
 
-    $scope.$on('updateControllerData', function (event, data) {
-        if (data.indexOf('main.transactions') != -1) {
-            $scope.updateAppView();
-        }
-    });
-
     $scope.$on('$destroy', function () {
         $interval.cancel($scope.balanceInterval);
         $scope.balanceInterval = null;
@@ -142,9 +136,11 @@ angular.module('liskApp').controller('accountController', ['$state','$scope', '$
     }
 
     $scope.$on('updateControllerData', function (event, data) {
-        if (data.indexOf('main.dashboard') != -1 && $state.current.name=="main.dashboard") {
+	    $scope.$$listeners.updateControllerData.splice(1);
+        if ((data.indexOf('main.dashboard') != -1 && $state.current.name=="main.dashboard") || data.indexOf('main.transactions') != -1) {
             $scope.updateAppView();
         }
+
     });
 
     $scope.updateAppView();

--- a/js/controllers/forgingController.js
+++ b/js/controllers/forgingController.js
@@ -162,7 +162,7 @@ angular.module('liskApp').controller('forgingController', ['$scope', '$rootScope
             }
             $scope.uptime = response.productivity || 0;
 
-            var approval = parseFloat(response.approval || 0);;
+            var approval = parseFloat(response.approval || 0);
 
             $scope.graphs.approval.values = [approval, 100 - approval];
             if (($scope.approval == 0 && approval > 0) || ($scope.approval >= 95 && approval < 95) || ($scope.approval >= 50 && approval < 50)) {


### PR DESCRIPTION
The problem was that each usage of "updateControllerData" assigned one 

$scope.updateAppView();

to the angular listener. Leading to several updateAppView functions being called after several loads of the Dashboard. By using:

$scope.$$listeners.updateControllerData.splice(1);

I am limiting the current API call set to 1, therefore still allowing it to be there but not several instances. This is especially important because the updateAppView does:

getAccount
getTransactions
getDelegate

API calls, which can be consuming especially for much used accounts.